### PR TITLE
Feature/semver tag selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The recipe for the solution is a text file called `recipe.txt` in the Solution's
 Service Modules are added to the Solution by appending their name to the recipe. A list of supported Service Modules can be found in `mirrordirector.py`.
 
 ### Specifing versions of Service Modules
-A particular branch or tag of that Service Module's codebase can be used by adding `=branchname` after the name of the Service Module. If this is not supplied, that Service Module's default branch will be used. Release tags can be partially specified with the any wildcard *, in which case the highest SemVer release that begins as specified will be used. <!--Unfortunately dashed suffixes take precedence over tags without a suffix, in contrast to SemVer -->
+A particular branch or tag of that Service Module's codebase can be used by adding `=branchname` after the name of the Service Module. If this is not supplied, that Service Module's default branch will be used. Release tags can be partially specified with the any wildcard *, in which case the highest SemVer release that begins as specified will be used. <!-- Note that prereleases/dashed suffixes are exlcuded from the search, if you want to use one it must be named in full for an exact match. -->
 
 An example valid `recipe.txt`:
 ```

--- a/README.md
+++ b/README.md
@@ -10,20 +10,25 @@ An "assembler" then runs on the recipe and gathers the Service Modules from resp
 
 ## Writing a recipe
 The recipe for the solution is a text file called `recipe.txt` in the Solution's root directory.  
-Service Modules are added to the Solution by appending their name to the recipe. A list of supported Service Modules can be found in `mirrordirector.py`.
+Service Modules are added to the Solution by appending their name to the recipe. Each Service Module must have its own line in `recipe.txt`.    
+A list of supported Service Modules can be found in `mirrordirector.py`.
 
 ### Specifing versions of Service Modules
-A particular branch or tag of that Service Module's codebase can be used by adding `=branchname` after the name of the Service Module. If this is not supplied, that Service Module's default branch will be used. Release tags can be partially specified with the any wildcard *, in which case the highest SemVer release that begins as specified will be used. <!-- Note that prereleases/dashed suffixes are exlcuded from the search, if you want to use one it must be named in full for an exact match. -->
+A particular branch or tag of that Service Module's codebase can be specified by adding `=branchname` after the name of the Service Module. If this is not supplied, that Service Module's default branch will be used. Release tags can be specified in the same way.  
 
-An example valid `recipe.txt`:
+Semantically versioned release tags can be partially specified. Where an exact branch or tag match is not available, the tag with the highest SemVer precedence that begins as specified will be used.  
+Note that prereleases (tags with dashed suffixes) will not be automatically selected.  
+
+An example of a valid `recipe.txt`:
 ```
 Grafana
 MQTTBroker=main
 Sensing=feature/recipe-lite
 Telemetry=v1.2.3
-SetupLogging=v1.*
+SetupLogging=v1.6
 ```
-In this case the branch of SetupLogging downloaded would be the latest release of version 1. Note the inclusion of the . before the *, which prevents v10 and onwards being selected.
+Assuming the exact tag `v1.2.3` exists for Telemetry, this will be used.  
+Assuming the eact tag `v1.6` does not exist for SetupLogging, `v1.6.2` would be selected over `v1.6.1`, but `v1.6.3-rc4` would be ignored.
 
 ### Multiple of the same Service Module
 Multiple instances of the same Service Module are supported. Simply duplicate the lines in the recipe:
@@ -31,7 +36,7 @@ Multiple instances of the same Service Module are supported. Simply duplicate th
 Sensing=feature/recipe-lite
 Sensing=feature/recipe-lite
 ```
-This will create two Sensing Service Modules in your Solution. They can be on the same or different branches. 
+This will create two Sensing Service Modules in your Solution. They can be on the same or different branches/tags. 
 When assembled, the Sensing Service Module will be cloned first into `ServiceModules/Sensing` and then also into `ServiceModules/Sensing2`
 
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ An "assembler" then runs on the recipe and gathers the Service Modules from resp
 
 ## Writing a recipe
 The recipe for the solution is a text file called `recipe.txt` in the Solution's root directory.  
-Service Modules are added to the Solution by appending their name to the recipe. A list of supported Service Modules can be found in `mirrordirector.py`.  
-A particular branch or tag of that Service Module's codebase can be used by adding `=branchname` after the name of the Service Module. If this is not supplied, that Service Module's default branch will be used.
+Service Modules are added to the Solution by appending their name to the recipe. A list of supported Service Modules can be found in `mirrordirector.py`.
 
-An example `recipe.txt`:
+### Specifing versions of Service Modules
+A particular branch or tag of that Service Module's codebase can be used by adding `=branchname` after the name of the Service Module. If this is not supplied, that Service Module's default branch will be used. Release tags can be partially specified with the any wildcard *, in which case the highest SemVer release that begins as specified will be used. <!--Unfortunately dashed suffixes take precedence over tags without a suffix, in contrast to SemVer -->
+
+An example valid `recipe.txt`:
 ```
 Grafana
-MQTTBroker=master
+MQTTBroker=main
 Sensing=feature/recipe-lite
+Telemetry=v1.2.3
+SetupLogging=v1.*
 ```
-
+In this case the branch of SetupLogging downloaded would be the latest release of version 1. Note the inclusion of the . before the *, which prevents v10 and onwards being selected.
 
 ### Multiple of the same Service Module
 Multiple instances of the same Service Module are supported. Simply duplicate the lines in the recipe:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Telemetry=v1.2.3
 SetupLogging=v1.6
 ```
 Assuming the exact tag `v1.2.3` exists for Telemetry, this will be used.  
-Assuming the eact tag `v1.6` does not exist for SetupLogging, `v1.6.2` would be selected over `v1.6.1`, but `v1.6.3-rc4` would be ignored.
+Assuming the exact tag `v1.6` does not exist for SetupLogging, `v1.6.2` would be selected over `v1.6.1`, but `v1.6.3-rc4` would be ignored.
 
 ### Multiple of the same Service Module
 Multiple instances of the same Service Module are supported. Simply duplicate the lines in the recipe:

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -125,12 +125,13 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                                 if '-' in _suffix:  # if there is a dash in the unspecified part of the tag
                                     continue        # skip and continue search
 
-                                download_branch = tag
+                                _download_branch = tag
                                 break
 
-                        # if fallen through to here, a suitable branch/tag could not be found.
-                        print("ERROR: No suitable branch of", sm_base_name, "found for specifier", branch_specifier)
-                        continue
+                        # if _download_branch is still None, a suitable branch/tag could not be found.
+                        if _download_branch is None: # not acceptable here as within `if branch_specifier is not None:` far above.
+                            print("ERROR: No suitable branch of", sm_base_name, "found for specifier", branch_specifier, "Cancelling download of", sm_instance_name)
+                            continue    # give up on this line of the recipe and move on to next
 
             # Download with git clone
             download_to = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -79,9 +79,9 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
             _downloaded_service_modules.append(sm_instance_name)    # record final instance name used
 
             # Version management
-            # To remove the possibility of ending up with the wrong version downloaded, 
+            # To remove the possibility of ending up with the wrong version downloaded,
             # ensure the target branch or tag is available before attempting clone.
-            
+
             if branch_specifier is not None:
 
                 # Get list of remote branches
@@ -104,16 +104,16 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                     # If an exact tag match is available, take it
                     if branch_specifier in _available_tags:
                         _download_branch = branch_specifier
-                    
+
                     # If no exact branch or tag match, search for the tag that is the best semver match.
                     else:
-                        # Given that there was not an exact match, an unknown suffix will be found. 
+                        # Given that there was not an exact match, an unknown suffix will be found.
                         # It should not begin with a digit (e.g. if I asked for v1.6 I don't want v1.62)
                         # It should not begin with a - (as I desire to exclude prereleases from search, partially because git ls-remote can't get them in the semver order).
                         # Hence, the only acceptable next character is a full stop. Add this to the search term to exclude the above alternatives.
                         _branch_specifier_search = branch_specifier + '.'
-                        
-                        for tag in _available_tags: 
+
+                        for tag in _available_tags:
                             # _available_tags is already sorted by semver M.m.p highest precedence first when created.
                             if tag.startswith(_branch_specifier_search):
 
@@ -137,10 +137,10 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
             print()
             print("Downloading", sm_instance_name, "branch", _download_branch, "from specifier", branch_specifier)
             print("from", url, "to", download_to)
-            
+
             _download_command = "git clone " + url
             if _download_branch is not None:                    # If branch specified in recipe
-                _download_command += " -b " + _download_branch  # Insert into the clone command. Else omit. 
+                _download_command += " -b " + _download_branch  # Insert into the clone command. Else omit.
             _download_command += " " + download_to
 
             os.system(_download_command)                        # Run the string concatenated above

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -63,7 +63,7 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
 
         # Associate names
         sm_base_name = line[0]
-        if len(line) > 1:           # If an = was in the recipe line, try to use what follows as a branch/tab name.
+        if len(line) > 1:           # If an = was in the recipe line, try to use what follows as a branch/tag name.
             branch_specifier = line[1]
 
         # Attempt to action recipe line

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -112,6 +112,11 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                         # Known issue however: dashed suffixes superceed no suffix, which is anti-semver.
                         for tag in _available_tags: 
                             if tag.startswith(_branch_specifier_start):
+
+                                # Ignore prerelease tags
+                                if '-' in tag: # Not a perfect test (dashed prefixes will be caught as collateral)
+                                    continue
+
                                 download_branch = tag
                                 break
 

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -44,7 +44,13 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
         # Force reset - lest any be set in a previous loop, fail to update and are reused.
         sm_base_name = None
         url = None
-        branch_name = None      # Also supports not supplying a branch name and using SM repo default.
+        branch_specifier = None      # Also supports not supplying a branch name and using SM repo default.
+        _branch_specifier_start = None
+        _available_branches = None
+        _available_long_heads = None
+        _available_tags = None
+        _available_long_tags = None
+        _download_branch = None
         _download_command = ""
 
         # Skip line if blank or commented out python style
@@ -58,7 +64,7 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
         # Associate names
         sm_base_name = line[0]
         if len(line) > 1:           # If an = was in the recipe line, try to use what follows as a branch/tab name.
-            branch_name = line[1]
+            branch_specifier = line[1]
 
         # Attempt to action recipe line
         if sm_base_name in ServiceModuleURLs:
@@ -73,26 +79,63 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
             _downloaded_service_modules.append(sm_instance_name)    # record final instance name used
 
             # Version management
-            # If a recipe specifies v0.2.0, the tag v0.2.0 will be checked out. 
-            # Could a recipe specify v0.2 or v0.2.x, to allow the Assembler to find the highest SemVer tag before v0.3?
-            # Either clone the default branch, then view available tags, calculate target and checkout, or find tags online?
-            # However, previously the branch was part of the clone command from the begining, 
-            # to ensure if the branch was not found then the whole clone would fail lest we be left with a surprise branch.
+            # To remove the possibility of ending up with the wrong version downloaded, 
+            # ensure the target branch or tag is available before attempting clone.
+            
+            if branch_specifier is not None:
+
+                # Get list of remote branches
+                _available_long_heads = os.popen("git ls-remote --heads " + url).read().splitlines()
+                _available_branches = []
+                for head in _available_long_heads:
+                    _available_branches.append(head.split("heads/")[-1])    # Everything after heads/ , ie the name of the branch
+
+                # First attempt to clone an exact match of a branch name:
+                if branch_specifier in _available_branches:
+                    _download_branch = branch_specifier
+
+                else:
+                    # Get list of remote tags, sorted semver highest to lowest.
+                    _available_long_tags = os.popen("git ls-remote --tags --sort=-version:refname " + url).read().splitlines()
+                    _available_tags = []
+                    for tag in _available_long_tags:
+                        _available_tags.append(tag.split("tags/")[-1])      # Everything after tags/ , ie the name of the tag
+
+                    # If an exact tag match is available, take it
+                    if branch_specifier in _available_tags:
+                        _download_branch = branch_specifier
+                    
+                    else:
+                        # Strip any wildcard (*) if present and everything after it
+                        _branch_specifier_start = branch_specifier.split('*')[0] # everything up until the first *
+                        # _available_tags is already sorted by semver M.m.p highest first when created.
+                        # Known issue however: dashed suffixes superceed no suffix, which is anti-semver.
+                        for tag in _available_tags: 
+                            if tag.startswith(_branch_specifier_start):
+                                download_branch = tag
+                                break
+
+                        # if fallen through to here, a suitable branch/tag could not be found.
+                        print("ERROR: No suitable branch of", sm_base_name, "found for specifier", branch_specifier)
+                        continue
 
             # Download with git clone
             download_to = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))
             print()
-            print("Downloading", sm_instance_name, "branch", branch_name, "from", url, "to", download_to)
+            print("Downloading", sm_instance_name, "branch", _download_branch, "from specifier", branch_specifier)
+            print("from", url, "to", download_to)
+            
             _download_command = "git clone " + url
-            if branch_name is not None:                     # If branch specified in recipe
-                _download_command += " -b " + branch_name   # Insert into the clone command. Else omit. 
+            if _download_branch is not None:                    # If branch specified in recipe
+                _download_command += " -b " + _download_branch  # Insert into the clone command. Else omit. 
             _download_command += " " + download_to
-            os.system(_download_command)                    # Run the string concatenated above
+
+            os.system(_download_command)                        # Run the string concatenated above
 
 
         else:
             print()
-            print("Assembler Error: no Servie Module URL defined for line in recipe", line)
+            print("ERROR: no Servie Module URL defined for line in recipe", line)
             print()
 
 ## --------------------------------------------------------------------------------

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -23,7 +23,7 @@ from mirrordirector import ServiceModuleURLs
 recipefilename = "recipe.txt"
 
 # Define the solution files folder as 3 levels above this script.
-# Typically the stack will be <soluton_files>/ServiceModules/Assembly/ShoestringAssembler/SMDownloader.py
+# Typically the stack will be <solution_files>/ServiceModules/Assembly/ShoestringAssembler/SMDownloader.py
 solution_files = Path(__file__).parents[3]
 
 ## --------------------------------------------------------------------------------

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -72,6 +72,13 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                 sm_instance_name = sm_base_name + str(i)            # and try using name with count eg Sensing2
             _downloaded_service_modules.append(sm_instance_name)    # record final instance name used
 
+            # Version management
+            # If a recipe specifies v0.2.0, the tag v0.2.0 will be checked out. 
+            # Could a recipe specify v0.2 or v0.2.x, to allow the Assembler to find the highest SemVer tag before v0.3?
+            # Either clone the default branch, then view available tags, calculate target and checkout, or find tags online?
+            # However, previously the branch was part of the clone command from the begining, 
+            # to ensure if the branch was not found then the whole clone would fail lest we be left with a surprise branch.
+
             # Download with git clone
             download_to = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))
             print()


### PR DESCRIPTION
Support for approximately specified version tags in recipes. 
The tag with the [highest semantic version precedence](https://semver.org/spec/v2.0.0.html#spec-item-11) that begins as specified will be selected. Pre-releases are ignored. 

For example, if available tags are `v1.0.0`, `v1.1.0`, `v1.1.1`, `v1.2.0`, `v1.2.1`, `v1.2.2`, `v1.2.3-rc1`, `v1.3.0`, then requesting version `v1.2` would lead to `v1.2.2` being downloaded.
