### PR TITLE
Delete default config files in service module before linking

### DIFF
--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -48,7 +48,7 @@ print("Searching for docker-compose.yml in Service Modules...")
 for file in ServiceModulesDir.rglob('*'):
     if file.name in DOCKER_COMPOSE_FILE_NAMES:
         rel_path = file.relative_to(solution_files)
-        print("Including", rel_path, "in Solution docker-compose.yml")
+        print("    Including", rel_path, "in Solution docker-compose.yml")
         sub_compose_files.append(str(rel_path))
 
 print()

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -10,6 +10,9 @@
 # Building containers separately (result of quick test: dependency service remains undefined)
 # Including compose files - this is simply the one I am trying first.
 
+
+
+
 ## -- Imports ---------------------------------------------------------------------
 
 # standard imports
@@ -23,7 +26,10 @@ from pathlib import Path
 
 ## --------------------------------------------------------------------------------
 
-## -- Firm-coded settings ---------------------------------------------------------
+
+
+
+## -- Settings --------------------------------------------------------------------
 
 DOCKER_COMPOSE_FILE_NAMES = ['docker-compose.yml', 'docker-compose.yaml']   # for detecting sub compose files
 
@@ -34,7 +40,10 @@ ServiceModulesDir = solution_files.joinpath("ServiceModules")
 
 ## --------------------------------------------------------------------------------
 
-## -- iterate over service module folders -----------------------------------------
+
+
+
+## -- Iterate over service module folders to detect compose files -----------------
 
 sub_compose_files = []
 print()
@@ -54,6 +63,9 @@ for file in ServiceModulesDir.rglob('*'):
 print()
 
 ## --------------------------------------------------------------------------------
+
+
+
 
 ## -- Create the master docker-compose.yml ----------------------------------------
 #  --     iff there are service modules using docker 

--- a/link_config.py
+++ b/link_config.py
@@ -66,7 +66,7 @@ for SMDir in UserConfig.glob('*'):
             
             # If a file/dir/similar already exists in the destination, delete it to make way for replacement
             if dest_path.exists():
-                print("    Overwriting default config file at", dest_path)
+                print("    Deleting default config file at", dest_path)
                 os.system('rm -r "' + str(dest_path) + '"')
 
             # Hard link from the file in UserConfig to the config folder in the Service Module

--- a/link_config.py
+++ b/link_config.py
@@ -63,6 +63,13 @@ for SMDir in UserConfig.glob('*'):
 
         # if not a directory, it is a file item that can be linked
         else:
+            
+            # If a file/dir/similar already exists in the destination, delete it to make way for replacement
+            if dest_path.exists():
+                print("overwriting default config file at", dest_path)
+                os.system('rm -r "' + str(dest_path) + '"')
+
+            # Hard link from the file in UserConfig to the config folder in the Service Module
             print("linking", configitem, " to ", dest_path)
             # Note how below both "paths are in quotes" to support names with whitespace
             os.system('ln "' + str(configitem) + '" "' + str(dest_path) + '"')

--- a/link_config.py
+++ b/link_config.py
@@ -58,7 +58,7 @@ for SMDir in UserConfig.glob('*'):
         if configitem.is_dir():
             # ignore if already exists
             if not dest_path.exists():
-                print("making directory", dest_path)
+                print("    Making directory", dest_path)
                 os.mkdir(dest_path)
 
         # if not a directory, it is a file item that can be linked
@@ -66,10 +66,10 @@ for SMDir in UserConfig.glob('*'):
             
             # If a file/dir/similar already exists in the destination, delete it to make way for replacement
             if dest_path.exists():
-                print("Overwriting default config file at", dest_path)
+                print("    Overwriting default config file at", dest_path)
                 os.system('rm -r "' + str(dest_path) + '"')
 
             # Hard link from the file in UserConfig to the config folder in the Service Module
-            print("Linking", configitem, " to ", dest_path)
+            print("    Linking", configitem, " to ", dest_path)
             # Note how below both "paths are in quotes" to support names with whitespace
             os.system('ln "' + str(configitem) + '" "' + str(dest_path) + '"')

--- a/link_config.py
+++ b/link_config.py
@@ -70,6 +70,6 @@ for SMDir in UserConfig.glob('*'):
                 os.system('rm -r "' + str(dest_path) + '"')
 
             # Hard link from the file in UserConfig to the config folder in the Service Module
-            print("    Linking", configitem, " to ", dest_path)
+            print("    Linking", configitem, "to", dest_path)
             # Note how below both "paths are in quotes" to support names with whitespace
             os.system('ln "' + str(configitem) + '" "' + str(dest_path) + '"')

--- a/link_config.py
+++ b/link_config.py
@@ -66,10 +66,10 @@ for SMDir in UserConfig.glob('*'):
             
             # If a file/dir/similar already exists in the destination, delete it to make way for replacement
             if dest_path.exists():
-                print("overwriting default config file at", dest_path)
+                print("Overwriting default config file at", dest_path)
                 os.system('rm -r "' + str(dest_path) + '"')
 
             # Hard link from the file in UserConfig to the config folder in the Service Module
-            print("linking", configitem, " to ", dest_path)
+            print("Linking", configitem, " to ", dest_path)
             # Note how below both "paths are in quotes" to support names with whitespace
             os.system('ln "' + str(configitem) + '" "' + str(dest_path) + '"')


### PR DESCRIPTION
Remove burden on simple solutions to carry typical config files by making the inclusion of config files optional.

Allows service modules to be shipped with default config files that get replaced if a conflicting filename is found in UserConfig.