### PR TITLE
mirrordirector grouping

### DIFF
--- a/mirrordirector.py
+++ b/mirrordirector.py
@@ -5,22 +5,23 @@
 ServiceModuleURLs = {
 
     # Infrastructure modules
-    "Docker"        : "https://github.com/DigitalShoestringSolutions/Docker",
-    "SetupLogging"  : "https://github.com/DigitalShoestringSolutions/SetupLogging",
+    "Docker"            : "https://github.com/DigitalShoestringSolutions/Docker",
+    "SetupLogging"      : "https://github.com/DigitalShoestringSolutions/SetupLogging",
 
     # Data collection modules
-    "Sensing"       : "https://github.com/DigitalShoestringSolutions/sm_SensingDC",
+    "Sensing"           : "https://github.com/DigitalShoestringSolutions/sm_SensingDC",
 
     # Data transfer modules
-    "MQTTBroker"    : "https://github.com/DigitalShoestringSolutions/sm_mqtt_broker",
+    "MQTTBroker"        : "https://github.com/DigitalShoestringSolutions/sm_mqtt_broker",
 
     # Data storage modules
-    "InfluxDB"    : "https://github.com/DigitalShoestringSolutions/sm_timeseries_db",
+    "InfluxDB"          : "https://github.com/DigitalShoestringSolutions/sm_timeseries_db",
 
     # User interface modules
-    "Grafana"       : "https://github.com/DigitalShoestringSolutions/sm_grafana_ui",
+    "Grafana"           : "https://github.com/DigitalShoestringSolutions/sm_grafana_ui",
 
     # Data output modules
-    "ReportGen"     : "https://github.com/DigitalShoestringSolutions/sm_ReportGeneration",
-    "AWSRelay"      : "https://github.com/DigitalShoestringSolutions/AWSRelay",
+    "ReportGen"         : "https://github.com/DigitalShoestringSolutions/sm_ReportGeneration",
+    "ReportGeneration"  : "https://github.com/DigitalShoestringSolutions/sm_ReportGeneration",
+    "AWSRelay"          : "https://github.com/DigitalShoestringSolutions/AWSRelay",
 }

--- a/mirrordirector.py
+++ b/mirrordirector.py
@@ -17,6 +17,8 @@ ServiceModuleURLs = {
 
     # Data storage modules
     "InfluxDB"          : "https://github.com/DigitalShoestringSolutions/sm_timeseries_db",
+    "InfluxEditor"      : "https://github.com/DigitalShoestringSolutions/sm_flux_sds_edit",
+    "LocationsDB"       : "https://github.com/DigitalShoestringSolutions/location_ds",
 
     # User interface modules
     "Grafana"           : "https://github.com/DigitalShoestringSolutions/sm_grafana_ui",

--- a/mirrordirector.py
+++ b/mirrordirector.py
@@ -4,14 +4,23 @@
 
 ServiceModuleURLs = {
 
+    # Infrastructure modules
+    "Docker"        : "https://github.com/DigitalShoestringSolutions/Docker",
     "SetupLogging"  : "https://github.com/DigitalShoestringSolutions/SetupLogging",
+
+    # Data collection modules
+    "Sensing"       : "https://github.com/DigitalShoestringSolutions/sm_SensingDC",
+
+    # Data transfer modules
+    "MQTTBroker"    : "https://github.com/DigitalShoestringSolutions/sm_mqtt_broker",
+
+    # Data storage modules
+    "InfluxDB"    : "https://github.com/DigitalShoestringSolutions/sm_timeseries_db",
+
+    # User interface modules
+    "Grafana"       : "https://github.com/DigitalShoestringSolutions/sm_grafana_ui",
+
+    # Data output modules
     "ReportGen"     : "https://github.com/DigitalShoestringSolutions/sm_ReportGeneration",
     "AWSRelay"      : "https://github.com/DigitalShoestringSolutions/AWSRelay",
-    "Grafana"       : "https://github.com/DigitalShoestringSolutions/sm_grafana_ui",
-    "MQTTBroker"    : "https://github.com/DigitalShoestringSolutions/sm_mqtt_broker",
-    "Timeseries"    : "https://github.com/DigitalShoestringSolutions/sm_timeseries_db",
-    "Telemetry"     : "https://github.com/DigitalShoestringSolutions/Telemetry",
-    "Sensing"       : "https://github.com/DigitalShoestringSolutions/sm_SensingDC",
-    "Docker"        : "https://github.com/DigitalShoestringSolutions/Docker"
-
 }

--- a/mirrordirector.py
+++ b/mirrordirector.py
@@ -7,6 +7,7 @@ ServiceModuleURLs = {
     # Infrastructure modules
     "Docker"            : "https://github.com/DigitalShoestringSolutions/Docker",
     "SetupLogging"      : "https://github.com/DigitalShoestringSolutions/SetupLogging",
+    "Assembler"         : "https://github.com/DigitalShoestringSolutions/ShoestringAssembler",
 
     # Data collection modules
     "Sensing"           : "https://github.com/DigitalShoestringSolutions/sm_SensingDC",


### PR DESCRIPTION
Grouped the service modules in mirrordirector in a similar way to the [default recipe in the starter solution template](https://github.com/DigitalShoestringSolutions/starter-solution-template/commit/1e55b3d59bbe25391503a7c855dc9671289e94ef)

Removed Telemetry from mirrordirector as Telemetry repo was deleted. No replacement (deployment stats collection) yet published.