### PR TITLE
Feature/Generate start.sh and stop.sh

### DIFF
--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -88,7 +88,7 @@ if len(sub_compose_files) > 0:
 
         # Open for exclusive creation. Fail if file already exists, as if block already checked.
         with open(start_path, 'x') as f:
-            f.write('CURRENT_UID="$(id -u)" docker-compose up')
+            f.write('CURRENT_UID="$(id -u)" docker compose up -d')
 
         # Set executable bit. Uses absolute file path.
         os.popen("chmod +x " + str(start_path))

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -81,7 +81,7 @@ if len(sub_compose_files) > 0:
 
     # If the solution is using compose, also create ./start.sh if not already present in the solution
     
-    start_path = solution_files.joinpath("./start.sh")
+    start_path = solution_files.joinpath("start.sh")
     print(start_path)
     if not start_path.exists():
         print("    Creating", start_path)
@@ -90,11 +90,11 @@ if len(sub_compose_files) > 0:
         with open(start_path, 'x') as f:
             f.write('CURRENT_UID="$(id -u)" docker-compose up')
 
-        # Set executable bit
-        os.popen("chmod=+x " + start_path)
+        # Set executable bit. Uses absolute file path.
+        os.popen("chmod +x " + str(start_path))
 
     else:
-        print("    ./start.sh already exists")
+        print("    start.sh already exists")
 
 
 print("## -----------------------------------------------------------------------")

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -3,12 +3,7 @@
 # Creates a docker-compose.yml file in the solution files directory.
 # Detects docker-compose files in service modules and includes them in the master docker-compose file
 # does not use the recipe file directly, as some service modules may not have docker-compose elements (eg SetupLogging)
-
-# There are many approaches to the problem this is trying to solve, including:
-# Merging compose files
-# Extending compose files
-# Building containers separately (result of quick test: dependency service remains undefined)
-# Including compose files - this is simply the one I am trying first.
+#     and bespoke service modules using compose may be included with the solution (and hence not in the recipe)
 
 
 

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -12,6 +12,7 @@
 
 # standard imports
 from pathlib import Path
+import os
 
 # installed imports
 #none
@@ -56,12 +57,12 @@ for file in ServiceModulesDir.rglob('*'):
         print("    Including", rel_path, "in Solution docker-compose.yml")
         sub_compose_files.append(str(rel_path))
 
-## --------------------------------------------------------------------------------
+## -------------------------------------------------------------------------------
 
 
 
 
-## -- Create the master docker-compose.yml ----------------------------------------
+## -- Create the master docker-compose.yml and ./start.sh and ./stop.sh ----------
 #  --     iff there are service modules using docker 
 
 if len(sub_compose_files) > 0:
@@ -77,6 +78,26 @@ if len(sub_compose_files) > 0:
         master_compose_file.write('\n')
         master_compose_file.writelines(['networks:\n', '     internal:\n', '         name: shoestring-internal'])
 
+
+    # If the solution is using compose, also create ./start.sh if not already present in the solution
+    
+    start_path = solution_files.joinpath(repr("./start.sh"))
+    if not start_path.exists:
+        
+        # repr() returns a string in its printable format, i.e doesn’t resolve the escape sequences
+        print(repr("    Creating ./start.sh"))
+        
+        # Open for exclusive creation. Fail if file already exists, as if block already checked.
+        with open(start_path, 'x') as f:
+            f.write(repr('CURRENT_UID="$(id -u)" docker-compose up'))
+
+        # Set executable bit
+        os.popen(repr("chmod=+x ./start.sh"))
+    
+    else:
+        print(repr("    ./start.sh already exists"))
+
+    
 print("## -----------------------------------------------------------------------")
 
 ## --------------------------------------------------------------------------------

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -82,20 +82,21 @@ if len(sub_compose_files) > 0:
     # If the solution is using compose, also create ./start.sh if not already present in the solution
     
     start_path = solution_files.joinpath(repr("./start.sh"))
+    print(start_path)
     if not start_path.exists:
         
         # repr() returns a string in its printable format, i.e doesn’t resolve the escape sequences
-        print(repr("    Creating ./start.sh"))
+        print("    Creating ./start.sh")
         
         # Open for exclusive creation. Fail if file already exists, as if block already checked.
         with open(start_path, 'x') as f:
-            f.write(repr('CURRENT_UID="$(id -u)" docker-compose up'))
+            f.write('CURRENT_UID="$(id -u)" docker-compose up')
 
         # Set executable bit
         os.popen(repr("chmod=+x ./start.sh"))
     
     else:
-        print(repr("    ./start.sh already exists"))
+        print("    ./start.sh already exists")
 
     
 print("## -----------------------------------------------------------------------")

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -79,23 +79,21 @@ if len(sub_compose_files) > 0:
         master_compose_file.writelines(['networks:\n', '     internal:\n', '         name: shoestring-internal'])
 
 
-    # If the solution is using compose, also create ./start.sh if not already present in the solution
+    # If the solution is using compose, also create start.sh and stop.sh if not already present in the solution
+    for st in (('start.sh', 'CURRENT_UID="$(id -u)" docker compose up -d'), ('stop.sh', 'docker compose down')):
+        st_path = solution_files.joinpath(st[0])
+        if not st_path.exists():
+            print("    Creating", st_path)
     
-    start_path = solution_files.joinpath("start.sh")
-    print(start_path)
-    if not start_path.exists():
-        print("    Creating", start_path)
+            # Open for exclusive creation. Fail if file already exists, as if block already checked.
+            with open(st_path, 'x') as f:
+                f.write(st[1])
+    
+            # Set executable bit. Uses absolute file path.
+            os.popen("chmod +x " + str(st_path))
 
-        # Open for exclusive creation. Fail if file already exists, as if block already checked.
-        with open(start_path, 'x') as f:
-            f.write('CURRENT_UID="$(id -u)" docker compose up -d')
-
-        # Set executable bit. Uses absolute file path.
-        os.popen("chmod +x " + str(start_path))
-
-    else:
-        print("    start.sh already exists")
-
+        else:
+            print("    ", st_path, "already exists")
 
 print("## -----------------------------------------------------------------------")
 

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -83,7 +83,7 @@ if len(sub_compose_files) > 0:
     
     start_path = solution_files.joinpath(repr("./start.sh"))
     print(start_path)
-    if not start_path.exists:
+    if not start_path.exists():
         
         # repr() returns a string in its printable format, i.e doesn’t resolve the escape sequences
         print("    Creating ./start.sh")

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -81,24 +81,22 @@ if len(sub_compose_files) > 0:
 
     # If the solution is using compose, also create ./start.sh if not already present in the solution
     
-    start_path = solution_files.joinpath(repr("./start.sh"))
+    start_path = solution_files.joinpath("./start.sh")
     print(start_path)
     if not start_path.exists():
-        
-        # repr() returns a string in its printable format, i.e doesn’t resolve the escape sequences
-        print("    Creating ./start.sh")
-        
+        print("    Creating", start_path)
+
         # Open for exclusive creation. Fail if file already exists, as if block already checked.
         with open(start_path, 'x') as f:
             f.write('CURRENT_UID="$(id -u)" docker-compose up')
 
         # Set executable bit
-        os.popen(repr("chmod=+x ./start.sh"))
-    
+        os.popen("chmod=+x " + start_path)
+
     else:
         print("    ./start.sh already exists")
 
-    
+
 print("## -----------------------------------------------------------------------")
 
 ## --------------------------------------------------------------------------------


### PR DESCRIPTION
Rather than ship `start.sh` and `stop.sh` with the solutions - let the Assembler create them when Service Modules using `docker compose` are detected.

They're not solution specific. They shouldn't be duplicated across solutions.

This PR extends the `include_docker_composes.py` to create these files in the solution files folder. 