### PR TITLE
Feature/Local log file

### DIFF
--- a/assemble.sh
+++ b/assemble.sh
@@ -6,13 +6,13 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a assemblerlog.txt
+python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a assemblerlog.txt
+python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a assemblerlog.txt
+python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a assemblerlog.txt
+python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt

--- a/assemble.sh
+++ b/assemble.sh
@@ -5,6 +5,10 @@
 # Get location of this script
 SCRIPT_DIR="$(dirname -- "$(realpath -- "$0")")"
 
+# Get location of this script's parent folder
+PARENT_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
+echo $PARENT_DIR
+
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
 

--- a/assemble.sh
+++ b/assemble.sh
@@ -10,16 +10,16 @@ SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep .1
+sleep 3
 
 # Run init files in each service module, if present
 python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep .1
+sleep 3
 
 # Link config files between UserConfig and each Service Module's config dirctory
 python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep .1
+sleep 3
 
 # Generate a docker-compose file at <solutionfiles>
 python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep .1
+sleep 3

--- a/assemble.sh
+++ b/assemble.sh
@@ -13,15 +13,15 @@ SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
 
 
+echo "## --------------------------------------------------------------------------------"
 
-# Print the version of the Solution and Assembler being used
-echo "Solution hash:" 2>&1 | tee -a $LOG_FILE
+# Print the version of the Solution and Assembler being used. echo -n for no newline at end.
+echo -n "Solution hash: " 2>&1 | tee -a $LOG_FILE
 git rev-parse --short HEAD 2>&1 | tee -a $LOG_FILE
-
-echo "Assembler hash:" 2>&1 | tee -a $LOG_FILE
+echo -n "Assembler hash: " 2>&1 | tee -a $LOG_FILE
 git -C $SCRIPT_DIR rev-parse --short HEAD 2>&1 | tee -a $LOG_FILE
 
-
+echo "## --------------------------------------------------------------------------------"
 
 # Run the Assembler!
 # Download Service Modules into <solutionfiles>/ServiceModules

--- a/assemble.sh
+++ b/assemble.sh
@@ -10,12 +10,16 @@ PARENT_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+sleep .1
 
 # Run init files in each service module, if present
 python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+sleep .1
 
 # Link config files between UserConfig and each Service Module's config dirctory
 python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+sleep .1
 
 # Generate a docker-compose file at <solutionfiles>
 python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+sleep .1

--- a/assemble.sh
+++ b/assemble.sh
@@ -35,12 +35,15 @@ echo "## -----------------------------------------------------------------------
 # Assembler functional steps
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py
+echo ""
 
 # Run init files in each service module, if present
 python3 $SCRIPT_DIR/init_SMs.py
+echo ""
 
 # Link config files between UserConfig and each Service Module's config dirctory
 python3 $SCRIPT_DIR/link_config.py
+echo ""
 
 # Generate a docker-compose file at <solutionfiles>
 python3 $SCRIPT_DIR/include_docker_composes.py

--- a/assemble.sh
+++ b/assemble.sh
@@ -6,13 +6,13 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py
+python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee assemblerlog.txt
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py
+python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee assemblerlog.txt
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py
+python3 $SCRIPT_DIR/link_config.py 2>&1 | tee assemblerlog.txt
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py
+python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee assemblerlog.txt

--- a/assemble.sh
+++ b/assemble.sh
@@ -15,7 +15,7 @@ LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
 
 # Run the Assembler!
 # Print the version of the Assembler being used
-echo "git log --oneline -1" 2>&1 | tee -a $LOG_FILE
+git -C $SCRIPT_DIR log --oneline -1 2>&1 | tee -a $LOG_FILE
 
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $LOG_FILE

--- a/assemble.sh
+++ b/assemble.sh
@@ -3,7 +3,7 @@
 # Top level of Shoestring Assembler
 
 # Get location of this script
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR="$(dirname -- "$(realpath -- "$0")")"
 
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt

--- a/assemble.sh
+++ b/assemble.sh
@@ -13,25 +13,32 @@ SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
 
 
+# Wrap all commands to redirect IO. Closed in the last line. 
+{
+
+#
 echo "## --------------------------------------------------------------------------------"
 
 # Print the version of the Solution and Assembler being used. echo -n for no newline at end.
-echo -n "Solution hash: " 2>&1 | tee -a $LOG_FILE
-git rev-parse --short HEAD 2>&1 | tee -a $LOG_FILE
-echo -n "Assembler hash: " 2>&1 | tee -a $LOG_FILE
-git -C $SCRIPT_DIR rev-parse --short HEAD 2>&1 | tee -a $LOG_FILE
+echo -n "Solution hash: "
+git rev-parse --short HEAD
+echo -n "Assembler hash: "
+git -C $SCRIPT_DIR rev-parse --short HEAD
 
 echo "## --------------------------------------------------------------------------------"
 
 # Run the Assembler!
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $LOG_FILE
+python3 $SCRIPT_DIR/SMDownloader.py
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $LOG_FILE
+python3 $SCRIPT_DIR/init_SMs.py
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $LOG_FILE
+python3 $SCRIPT_DIR/link_config.py
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $LOG_FILE
+python3 $SCRIPT_DIR/include_docker_composes.py
+
+# Wrap all of the above, send stdout & stderr to local log file
+} 2>&1 | tee -a $LOG_FILE

--- a/assemble.sh
+++ b/assemble.sh
@@ -10,16 +10,12 @@ SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep 3
 
 # Run init files in each service module, if present
 python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep 3
 
 # Link config files between UserConfig and each Service Module's config dirctory
 python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep 3
 
 # Generate a docker-compose file at <solutionfiles>
 python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
-sleep 3

--- a/assemble.sh
+++ b/assemble.sh
@@ -13,10 +13,17 @@ SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
 
 
-# Run the Assembler!
-# Print the version of the Assembler being used
-git -C $SCRIPT_DIR log --oneline -1 2>&1 | tee -a $LOG_FILE
 
+# Print the version of the Solution and Assembler being used
+echo "Solution hash:" 2>&1 | tee -a $LOG_FILE
+git rev-parse --short HEAD 2>&1 | tee -a $LOG_FILE
+
+echo "Assembler hash:" 2>&1 | tee -a $LOG_FILE
+git -C $SCRIPT_DIR rev-parse --short HEAD 2>&1 | tee -a $LOG_FILE
+
+
+
+# Run the Assembler!
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $LOG_FILE
 

--- a/assemble.sh
+++ b/assemble.sh
@@ -7,16 +7,15 @@ SCRIPT_DIR="$(dirname -- "$(realpath -- "$0")")"
 
 # Get location of this script's parent folder
 PARENT_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
-echo $PARENT_DIR
 
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $SCRIPT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt

--- a/assemble.sh
+++ b/assemble.sh
@@ -2,24 +2,24 @@
 
 # Top level of Shoestring Assembler
 
-# Get location of this script
+# Get the parent dir of this script
 SCRIPT_DIR="$(dirname -- "$(realpath -- "$0")")"
 
-# Get location of this script's parent folder
-PARENT_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
+# Get the parent dir of SCRIPT_DIR
+SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
 sleep .1
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
 sleep .1
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
 sleep .1
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $PARENT_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
 sleep .1

--- a/assemble.sh
+++ b/assemble.sh
@@ -28,6 +28,7 @@ echo -n "Assembler hash: "
 git -C $SCRIPT_DIR rev-parse --short HEAD
 
 echo "## -----------------------------------------------------------------------"
+echo -e "\n" # print two blank lines to terminal / log. 
 
 
 
@@ -35,15 +36,15 @@ echo "## -----------------------------------------------------------------------
 # Assembler functional steps
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py
-echo ""
+echo -e "\n"
 
 # Run init files in each service module, if present
 python3 $SCRIPT_DIR/init_SMs.py
-echo ""
+echo -e "\n"
 
 # Link config files between UserConfig and each Service Module's config dirctory
 python3 $SCRIPT_DIR/link_config.py
-echo ""
+echo -e "\n"
 
 # Generate a docker-compose file at <solutionfiles>
 python3 $SCRIPT_DIR/include_docker_composes.py

--- a/assemble.sh
+++ b/assemble.sh
@@ -6,13 +6,13 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee assemblerlog.txt
+python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a assemblerlog.txt
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee assemblerlog.txt
+python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a assemblerlog.txt
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py 2>&1 | tee assemblerlog.txt
+python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a assemblerlog.txt
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee assemblerlog.txt
+python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a assemblerlog.txt

--- a/assemble.sh
+++ b/assemble.sh
@@ -13,11 +13,13 @@ SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
 
 
+
+
 # Wrap all commands to redirect IO. Closed in the last line. 
 {
 
-#
-echo "## --------------------------------------------------------------------------------"
+# Standard length divider
+echo "## -----------------------------------------------------------------------"
 
 # Print the version of the Solution and Assembler being used. echo -n for no newline at end.
 echo -n "Solution hash: "
@@ -25,9 +27,12 @@ git rev-parse --short HEAD
 echo -n "Assembler hash: "
 git -C $SCRIPT_DIR rev-parse --short HEAD
 
-echo "## --------------------------------------------------------------------------------"
+echo "## -----------------------------------------------------------------------"
 
-# Run the Assembler!
+
+
+
+# Assembler functional steps
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py
 
@@ -39,6 +44,9 @@ python3 $SCRIPT_DIR/link_config.py
 
 # Generate a docker-compose file at <solutionfiles>
 python3 $SCRIPT_DIR/include_docker_composes.py
+
+
+
 
 # Wrap all of the above, send stdout & stderr to local log file
 } 2>&1 | tee -a $LOG_FILE

--- a/assemble.sh
+++ b/assemble.sh
@@ -8,14 +8,18 @@ SCRIPT_DIR="$(dirname -- "$(realpath -- "$0")")"
 # Get the parent dir of SCRIPT_DIR
 SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 
+# Define a 
+LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
+
+
 # Download Service Modules into <solutionfiles>/ServiceModules
-python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $LOG_FILE
 
 # Run init files in each service module, if present
-python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/init_SMs.py 2>&1 | tee -a $LOG_FILE
 
 # Link config files between UserConfig and each Service Module's config dirctory
-python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/link_config.py 2>&1 | tee -a $LOG_FILE
 
 # Generate a docker-compose file at <solutionfiles>
-python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $SCRIPT_DIR_DIR/assemblerlog.txt
+python3 $SCRIPT_DIR/include_docker_composes.py 2>&1 | tee -a $LOG_FILE

--- a/assemble.sh
+++ b/assemble.sh
@@ -2,15 +2,20 @@
 
 # Top level of Shoestring Assembler
 
+# Save some file paths as constants
 # Get the parent dir of this script
 SCRIPT_DIR="$(dirname -- "$(realpath -- "$0")")"
 
 # Get the parent dir of SCRIPT_DIR
 SCRIPT_DIR_DIR="$(dirname -- "$(realpath -- $SCRIPT_DIR)")"
 
-# Define a 
+# Define once the log file name, as a full path
 LOG_FILE=$SCRIPT_DIR_DIR/assemblerlog.txt
 
+
+# Run the Assembler!
+# Print the version of the Assembler being used
+echo "git log --oneline -1" 2>&1 | tee -a $LOG_FILE
 
 # Download Service Modules into <solutionfiles>/ServiceModules
 python3 $SCRIPT_DIR/SMDownloader.py 2>&1 | tee -a $LOG_FILE

--- a/include_docker_composes.py
+++ b/include_docker_composes.py
@@ -54,7 +54,7 @@ sub_compose_files = []
 for file in ServiceModulesDir.rglob('*'):
     if file.name in DOCKER_COMPOSE_FILE_NAMES:
         rel_path = file.relative_to(solution_files)
-        print("    Including", rel_path, "in Solution docker-compose.yml")
+        print("    Including", rel_path)
         sub_compose_files.append(str(rel_path))
 
 ## -------------------------------------------------------------------------------
@@ -93,7 +93,7 @@ if len(sub_compose_files) > 0:
             os.popen("chmod +x " + str(st_path))
 
         else:
-            print("    ", st_path, "already exists")
+            print("   ", st_path, "already exists")    # Only 3 leading spaces as print() inserts one between args
 
 print("## -----------------------------------------------------------------------")
 

--- a/link_config.py
+++ b/link_config.py
@@ -74,8 +74,8 @@ for SMDir in UserConfig.glob('*'):
                 os.system('rm -r "' + str(dest_path) + '"')
 
             # Hard link from the file in UserConfig to the config folder in the Service Module
-            print("    Linking", configitem)
-            print("        to ", dest_path)
+            print("    Linking", configitem_short)
+            print("        to ", dest_path_short)
             # Note how below both "paths are in quotes" to support names with whitespace
             os.system('ln "' + str(configitem) + '" "' + str(dest_path) + '"')
 


### PR DESCRIPTION
Adds a minimal logging capability to the Assembler. As discussed in #11 , this needs to keep it simple - can't yet use syslog etc. 

`stdout` and `stderr` are duplicated to a local text file using `tee`. In the future with telemetry this could be uploaded.

Typically if the solution contains `ServiceModules/Assembly/get_service_modules.sh`, the Assembler would be downloaded into `ServiceModules/Assembly/ShoestringAssembler/` , when run the file `ServiceModules/Assembly/assemblerlog.txt` will appear alongside it.

Also abridged some print output from assembly steps (show file paths relative to solution files instead of absolute)