### PR TITLE
Feature/sm updater

### DIFF
--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -67,7 +67,7 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
 
         # split line into list of components
         line = line.split("=")
-        line[-1] = line[-1].split("\n")[0]     # Remove trailing newline from last item.
+        line[-1] = line[-1].split("\n")[0]      # Remove trailing newline from last item.
 
         # Associate names
         sm_base_name = line[0]
@@ -78,13 +78,14 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
         if sm_base_name in ServiceModuleURLs:
             url = ServiceModuleURLs[sm_base_name]
 
-            # Duplicate management
+            # Duplicate management: find a unique "instance name" for this line of the recipe
             sm_instance_name = sm_base_name # First try to use the base name as the instance name
             i = 1
-            while sm_instance_name in _downloaded_service_modules:
-                i += 1                                              # If instance name taken, increment count
-                sm_instance_name = sm_base_name + str(i)            # and try using name with count eg Sensing2
-            _downloaded_service_modules.append(sm_instance_name)    # record final instance name used
+            while sm_instance_name in _downloaded_service_modules:                              # Check against list of instance names already taken
+                i += 1                                                                          # If instance name taken, increment count
+                sm_instance_name = sm_base_name + str(i)                                        # and try using name with count eg Sensing2
+            _downloaded_service_modules.append(sm_instance_name)                                # record final instance name used
+            download_dir = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))   # Directory to clone into
 
             # Version management
             # To remove the possibility of ending up with the wrong version downloaded,
@@ -145,16 +146,15 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                 _download_hash = os.popen("git ls-remote " + url + " " + _download_version).read()[:7]
 
             # Download with git clone
-            download_to = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))
             print()
             print("    Downloading", sm_instance_name, "version", _download_version, "(hash", _download_hash + ")", "from specifier", version_specifier)
             print("        from", url)
-            print("        to  ", download_to)
+            print("        to  ", download_dir)
 
             _download_command = "git clone --quiet " + url
             if _download_version is not None:                    # If branch specified in recipe
                 _download_command += " -b " + _download_version  # Insert into the clone command. Else omit.
-            _download_command += " " + download_to
+            _download_command += " " + download_dir
 
             os.system(_download_command)                        # Run the string concatenated above
 

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -169,7 +169,7 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                 # Hence, do not attempt to display old tag.
 
                 if current_hash == _download_hash:
-                    print(sm_instance_name, "existing version", _download_version, "(hash", _download_hash + ")", "is already suitable for specifier", version_specifier)
+                    print("    " + sm_instance_name, "existing version", _download_version, "(hash", _download_hash + ")", "is already suitable for specifier", version_specifier)
 
                 else: # need to update
                     print("    Updating", sm_instance_name, "from hash", current_hash, "to version", _download_version, "(hash", _download_hash + ")", "from specifier", version_specifier)

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -85,7 +85,7 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                 i += 1                                                                          # If instance name taken, increment count
                 sm_instance_name = sm_base_name + str(i)                                        # and try using name with count eg Sensing2
             _downloaded_service_modules.append(sm_instance_name)                                # record final instance name used
-            download_dir = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))   # Directory to clone into
+            instance_dir = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))   # Directory to clone into
 
             # Version management
             # To remove the possibility of ending up with the wrong version downloaded,
@@ -142,27 +142,54 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                             print("    ERROR: No suitable branch of", sm_base_name, "found for specifier", version_specifier, "Cancelling download of", sm_instance_name)
                             continue    # give up on this line of the recipe and move on to next
 
-                # Get the short commit hash from branch or tag name
+                # Get the short commit hash from branch or tag name. If no branches or tag match _download_Version, returns empty string
                 _download_hash = os.popen("git ls-remote " + url + " " + _download_version).read()[:7]
 
-            # Download with git clone
-            print()
-            print("    Downloading", sm_instance_name, "version", _download_version, "(hash", _download_hash + ")", "from specifier", version_specifier)
-            print("        from", url)
-            print("        to  ", download_dir)
+            
+            # Now that the target version has been identified, action this information
+            print() # in terminal and logs, give each recipe line a paragraph
 
-            _download_command = "git clone --quiet " + url
-            if _download_version is not None:                    # If branch specified in recipe
-                _download_command += " -b " + _download_version  # Insert into the clone command. Else omit.
-            _download_command += " " + download_dir
+            # If no such instance of the service module has been downloaded previously, clone a new one:
+            if not Path(instance_dir).exists():
+                print("    Downloading", sm_instance_name, "version", _download_version, "(hash", _download_hash + ")", "from specifier", version_specifier)
+                print("        from", url)
+                print("        to  ", instance_dir)
 
-            os.system(_download_command)                        # Run the string concatenated above
+                _download_command = "git clone --quiet " + url + " " + instance_dir
+                if _download_version is not None:                    # If branch specified in recipe
+                    _download_command += " -b " + _download_version  # Insert into the clone command. Else omit.
+                os.system(_download_command)                         # Run the string concatenated above
 
+            # If the service module instance clone already exists (likely by this script running previously), update that instance
+            else:
+                # Get information about existing clone
+                current_hash = os.popen("git -C " + instance_dir + " log --oneline -1").read()[:7]  # could also use rev parse head etc.
+                # Showing current tag is harder. git describe --exact-match --tags/--all is ok but not ideal (if no tags found, fatal message is insuppressible).
+                # tag display is not needed anyway when hashes are being compared. Only use is informing the user what the version being replaced was.
+                # Hence, do not attempt to display old tag.
+
+                if current_hash == _download_hash:
+                    print(sm_instance_name, "existing version", _download_version, "(hash", _download_hash + ")", "is already suitable for specifier", version_specifier)
+
+                else: # need to update
+                    print("    Updating", sm_instance_name, "from hash", current_hash, "to version", _download_version, "(hash", _download_hash + ")", "from specifier", version_specifier)
+                    # git checkout or git switch?
+                    # Need to stash changes eg replaced requirements files? No - lose them and relink from UserConfig. 
+                    #   Nothing should be changed in a SM outside of what is linked from UserConfig.
+                    # What will cause the checkout to abort? Possible hard reset required.
+                    os.system("git -C " + instance_dir + " checkout " + _download_version + " --quiet")
+
+                    # Confirm if the update was successful
+                    _post_update_hash = None # In case below line fails, don't let previously stored value persist.
+                    _post_update_hash = os.popen("git -C " + instance_dir + " log --oneline -1").read()[:7]  # could also use rev parse head etc.
+                    if _post_update_hash == _download_hash:
+                        print("    ", sm_instance_name, "has been sucessfully updated to", _post_update_hash)
+
+                    else:
+                        print("    ERROR: There was an issue during the checkout to", _download_hash + ".", sm_instance_name, "is still on hash", _post_update_hash)
 
         else:
-            print()
             print("ERROR: no Servie Module URL defined for line in recipe", line)
-            print()
 
 print("## -----------------------------------------------------------------------")
 

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -183,10 +183,10 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                     _post_update_hash = None # In case below line fails, don't let previously stored value persist.
                     _post_update_hash = os.popen("git -C " + instance_dir + " log --oneline -1").read()[:7]  # could also use rev parse head etc.
                     if _post_update_hash == _download_hash:
-                        print("    ", sm_instance_name, "has been sucessfully updated to", _post_update_hash)
+                        print("        " + sm_instance_name, "has been sucessfully updated to", _post_update_hash)
 
                     else:
-                        print("    ERROR: There was an issue during the checkout to", _download_hash + ".", sm_instance_name, "is still on hash", _post_update_hash)
+                        print("        ERROR: There was an issue during the checkout to", _download_hash + ".", sm_instance_name, "is still on hash", _post_update_hash)
 
         else:
             print("ERROR: no Servie Module URL defined for line in recipe", line)

--- a/SMDownloader.py
+++ b/SMDownloader.py
@@ -51,13 +51,13 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
         # Force reset - lest any be set in a previous loop, fail to update and are reused.
         sm_base_name = None
         url = None
-        branch_specifier = None      # Also supports not supplying a branch name and using SM repo default.
-        _branch_specifier_search = None
+        version_specifier = None      # Also supports not supplying a branch/tag name and using SM repo default.
+        _version_specifier_search = None
         _available_branches = None
         _available_long_heads = None
         _available_tags = None
         _available_long_tags = None
-        _download_branch = None
+        _download_version = None
         _download_hash = None
         _download_command = ""
 
@@ -71,8 +71,8 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
 
         # Associate names
         sm_base_name = line[0]
-        if len(line) > 1:           # If an = was in the recipe line, try to use what follows as a branch/tag name.
-            branch_specifier = line[1]
+        if len(line) > 1:               # If an = was in the recipe line, try to use what follows as a branch/tag name,
+            version_specifier = line[1] # else the default value of None will persist
 
         # Attempt to action recipe line
         if sm_base_name in ServiceModuleURLs:
@@ -90,7 +90,7 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
             # To remove the possibility of ending up with the wrong version downloaded,
             # ensure the target branch or tag is available before attempting clone.
 
-            if branch_specifier is not None:
+            if version_specifier is not None:
 
                 # Get list of remote branches
                 _available_long_heads = os.popen("git ls-remote --heads " + url).read().splitlines()
@@ -99,8 +99,8 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                     _available_branches.append(head.split("heads/")[-1])    # Everything after heads/ , ie the name of the branch
 
                 # First attempt to clone an exact match of a branch name:
-                if branch_specifier in _available_branches:
-                    _download_branch = branch_specifier
+                if version_specifier in _available_branches:
+                    _download_version = version_specifier
 
                 else:
                     # Get list of remote tags, sorted semver highest to lowest.
@@ -110,8 +110,8 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                         _available_tags.append(tag.split("tags/")[-1])      # Everything after tags/ , ie the name of the tag
 
                     # If an exact tag match is available, take it
-                    if branch_specifier in _available_tags:
-                        _download_branch = branch_specifier
+                    if version_specifier in _available_tags:
+                        _download_version = version_specifier
 
                     # If no exact branch or tag match, search for the tag that is the best semver match.
                     else:
@@ -119,41 +119,41 @@ with solution_files.joinpath(Path(recipefilename)).open(mode='r') as recipefile:
                         # It should not begin with a digit (e.g. if I asked for v1.6 I don't want v1.62)
                         # It should not begin with a - (as I desire to exclude prereleases from search, partially because git ls-remote can't get them in the semver order).
                         # Hence, the only acceptable next character is a full stop. Add this to the search term to exclude the above alternatives.
-                        _branch_specifier_search = branch_specifier + '.'
+                        _version_specifier_search = version_specifier + '.'
 
                         for tag in _available_tags:
                             # _available_tags is already sorted by semver M.m.p highest precedence first when created.
-                            if tag.startswith(_branch_specifier_search):
+                            if tag.startswith(_version_specifier_search):
 
                                 # Ignore prerelease tags
                                 # A request for v1.10 could so far pick up v1.10.2-rc3
                                 # Furthermore, it could select v1.10.2-rc3 over v1.10.2 due to ls-remote's imperfect ordering.
                                 # However, it would be excessive to ignore any tag with a dash in it. lite-v1.2.3 is a desired pickup from specifier lite-v1.2
-                                _suffix = tag[len(_branch_specifier_search):]
+                                _suffix = tag[len(_version_specifier_search):]
                                 if '-' in _suffix:  # if there is a dash in the unspecified part of the tag
                                     continue        # skip and continue search
 
-                                _download_branch = tag
+                                _download_version = tag
                                 break
 
-                        # if _download_branch is still None, a suitable branch/tag could not be found.
-                        if _download_branch is None: # not acceptable here as within `if branch_specifier is not None:` far above.
-                            print("    ERROR: No suitable branch of", sm_base_name, "found for specifier", branch_specifier, "Cancelling download of", sm_instance_name)
+                        # if _download_version is still None, a suitable branch/tag could not be found.
+                        if _download_version is None: # not acceptable here as within `if branch_specifier is not None:` far above.
+                            print("    ERROR: No suitable branch of", sm_base_name, "found for specifier", version_specifier, "Cancelling download of", sm_instance_name)
                             continue    # give up on this line of the recipe and move on to next
 
                 # Get the short commit hash from branch or tag name
-                _download_hash = os.popen("git ls-remote " + url + " " + _download_branch).read()[:7]
+                _download_hash = os.popen("git ls-remote " + url + " " + _download_version).read()[:7]
 
             # Download with git clone
             download_to = str(solution_files.joinpath("ServiceModules/" + sm_instance_name))
             print()
-            print("    Downloading", sm_instance_name, "branch", _download_branch, "(hash", _download_hash + ")", "from specifier", branch_specifier)
+            print("    Downloading", sm_instance_name, "version", _download_version, "(hash", _download_hash + ")", "from specifier", version_specifier)
             print("        from", url)
             print("        to  ", download_to)
 
             _download_command = "git clone --quiet " + url
-            if _download_branch is not None:                    # If branch specified in recipe
-                _download_command += " -b " + _download_branch  # Insert into the clone command. Else omit.
+            if _download_version is not None:                    # If branch specified in recipe
+                _download_command += " -b " + _download_version  # Insert into the clone command. Else omit.
             _download_command += " " + download_to
 
             os.system(_download_command)                        # Run the string concatenated above


### PR DESCRIPTION
Extends the functionality of `SMDownloader.py` to update modules.

If a clone of the targer module already exists, previously re-running `assemble.sh` (oft via `get_service_modules.sh`) would result in `fatal: destination path '...' already exists and is not an empty directory.`
This PR adds functionality to update existing clones if necessary.

The steps taken by  `SMDownloader.py` could now be described as:
```
* From the recipe, identify the remote tag required (as before)
* Check if the directory to clone the module into already exists
  * If not, clone a new instance of the required tag
  * If the destination already exists, probe what the latest commit hash is
    * If the current has matches the required tag, report no update needed
    * If they do not match, checkout the required tag
```
 
This seems well behaved:
![image](https://github.com/user-attachments/assets/4dbc492c-11f7-40a5-bfee-870b6da4c51e)
In the above test setup, the recipe previously specified `v1.0` and so `v1.0.2` was installed. The recipe was edited to `v1.1` and `assemble.sh` was run again. This is an extract from the output.

Running the script again results in this:
![image](https://github.com/user-attachments/assets/86e444fc-bb53-447f-8ce6-9f6df18db3ee)

Finally, if the files of the module are edited and the checkout fails, here is how those errors are handled:
![image](https://github.com/user-attachments/assets/4a0739aa-fcb2-4949-ba10-3ba24005a83c)
(as per #20 the messages above the first dashed line should appear last)
A hard reset of the config directory might be good for handling such 'normal' deviation from the tag.
